### PR TITLE
Nav: fix aria attributes

### DIFF
--- a/themes/hugo-theme-codex/layouts/partials/nav.html
+++ b/themes/hugo-theme-codex/layouts/partials/nav.html
@@ -1,4 +1,4 @@
-<nav class="nav" role="navigation">
+<nav class="nav" id="navigation">
   <ul class="nav__list">
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}


### PR DESCRIPTION
Lighthouse reports that the aria-controls attribute has an invalid value[1]. This
patch resolves it, fixing the lighthouse score.